### PR TITLE
Added start_url for PWA compatibility

### DIFF
--- a/bundle/site.webmanifest
+++ b/bundle/site.webmanifest
@@ -15,7 +15,8 @@
       "purpose": "maskable"
     }
   ],
-  "theme_color": "#ffffff",
+  "theme_color": "#006045",
   "background_color": "#ffffff",
-  "display": "standalone"
+  "display": "standalone",
+  "start_url": "https://lichen.adarid.de"
 }


### PR DESCRIPTION
start_url is required for PWA. See mozilla: https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps